### PR TITLE
Fix: 로그인시 localStorage 저장내용 변경, Header의 ProfileDropdown 수정

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -7,7 +7,6 @@ import { DashbaordSortType, GetPostResponseType } from '@/types/common';
 import { DASHBOARD_LIMIT } from '@/utils/constants';
 import { fetchWithInterceptor } from '@/utils/fetchWithInterceptor';
 import { API_ROUTE } from '@/utils/routes';
-import { useRouter } from 'next/navigation';
 import React, { useEffect, useState } from 'react';
 
 export default function Dashbaord() {
@@ -16,7 +15,6 @@ export default function Dashbaord() {
   const [resultData, setResultData] = useState<GetPostResponseType>();
   const [pagination, setPagination] = useState({ start: 1, click: 1, total: 1 });
   const [loading, setLoading] = useState<boolean>(false);
-  const router = useRouter();
 
   const { hasPrevPage, hasNextPage, totalPages, posts } = resultData
     ? resultData
@@ -60,15 +58,6 @@ export default function Dashbaord() {
       setLoading(false);
     }
   };
-
-  useEffect(() => {
-    const token = localStorage.getItem('token');
-    if (!token) {
-      router.replace('/login'); // 뒤로 돌아가기 불가능
-    }
-    
-    getResultItem();
-  }, []);
 
   useEffect(() => {
     getResultItem();

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -3,26 +3,24 @@ import { useEffect, useState } from 'react';
 import { usePathname, useRouter } from 'next/navigation';
 import Image from 'next/image';
 import ActionButton from '../common/button/ActionButton';
-import { HEADER_MENU } from '@/utils/routes';
+import { HEADER_MENU, PATH } from '@/utils/routes';
 import Link from 'next/link';
-
-interface User {
-  name: string;
-  profileImgUrl?: string;
-  // 필요한 다른 속성들을 추가 가능
-}
+import ProfileDropDown from './ProfileDropDown';
+import { GetUserInfoType } from '@/types/common';
 
 export default function Header() {
-  const [user, setUser] = useState<User | null>(null);
+  const [user, setUser] = useState<GetUserInfoType | null>(null);
   const router = useRouter();
   const pathname = usePathname();
-  const [isOpen, setIsOpen] = useState(false);
+
+  const loginRequiredPage = PATH.DASHBOARD || PATH.CREATE_URL || PATH.CREATE_IMAGE;
+  // 추후 마이페이지도 추가하기
 
   useEffect(() => {
     const token = localStorage.getItem('token') as string;
-    const userInfo = localStorage.getItem('userInfo');
-    if (userInfo) {
-      setUser(JSON.parse(userInfo));
+
+    if (!token && pathname === loginRequiredPage) {
+      router.push(PATH.LOGIN);
     } else {
       fetchUserInfo(token);
     }
@@ -39,8 +37,7 @@ export default function Header() {
       });
       const data = await response.json();
       if (response.ok) {
-        localStorage.setItem('userInfo', JSON.stringify(data.result.user));
-        setUser(data.result.user as User);
+        setUser(data.result.user as GetUserInfoType);
       } else {
         throw new Error(data.message || '사용자 정보를 불러오는데 실패했습니다.');
       }
@@ -52,12 +49,10 @@ export default function Header() {
 
   const handleLogout = () => {
     localStorage.removeItem('token');
-    localStorage.removeItem('userInfo');
     setUser(null);
     router.push('/login');
   };
 
-  const toggleDropdown = () => setIsOpen(!isOpen);
   const last_menu_num = HEADER_MENU.length - 1;
 
   return (
@@ -76,38 +71,7 @@ export default function Header() {
             ))}
           </ul>
           {user ? (
-            <div className="flex items-center gap-4 h-28 pl-20">
-              <div className="relative w-35 h-35 rounded-4 overflow-hidden">
-                <Image
-                  fill
-                  src={user.profileImgUrl ? user.profileImgUrl : '/images/default-profile.jpeg'}
-                  alt="유저 프로필 이미지"
-                />
-              </div>
-              <div className="ml-5">{user.name} 님</div>
-              <button
-                onClick={toggleDropdown}
-                className="flex items-center justify-center w-20 h-20 text-13 font-bold ml-8 text-gray bg-[#F9FAFB] rounded-[0.25rem]">
-                <Image
-                  src={isOpen ? '/images/arrow-line-s-t.svg' : '/images/arrow-line-s.svg'}
-                  alt="화살표 모양의 유저 프로필 드롭다운 버튼"
-                  width={16}
-                  height={16}
-                />
-              </button>
-              {isOpen && (
-                <div className="absolute top-60 mt-2 py-2 w-117 bg-white shadow-xl rounded z-50">
-                  <Link href="/mypage" className="block px-4 py-10 text-13 text-gray-700 hover:bg-gray-100">
-                    마이페이지
-                  </Link>
-                  <button
-                    onClick={handleLogout}
-                    className="w-full text-left px-4 py-10 text-13 text-gray-700 hover:bg-gray-100">
-                    로그아웃
-                  </button>
-                </div>
-              )}
-            </div>
+            <ProfileDropDown user={user} handleLogout={handleLogout} />
           ) : (
             <Link href="/login">
               <ActionButton text="시작하기" size="w-117 h-35 text-13 font-bold ml-20" />

--- a/src/components/layout/ProfileDropDown.tsx
+++ b/src/components/layout/ProfileDropDown.tsx
@@ -1,0 +1,66 @@
+import { GetUserInfoType } from '@/types/common';
+import Image from 'next/image';
+import Link from 'next/link';
+import { useEffect, useRef, useState } from 'react';
+
+interface ProfileDropDownProps {
+  user: GetUserInfoType;
+  handleLogout: () => void;
+}
+
+export default function ProfileDropDown({ user, handleLogout }: ProfileDropDownProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  const toggleDropdown = (event: React.MouseEvent<HTMLDivElement>) => {
+    event.stopPropagation();
+    event.preventDefault();
+    setIsOpen((prev) => !prev);
+  };
+
+  const handleClickOutside = (event: MouseEvent) => {
+    if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+      setIsOpen(false);
+    }
+  };
+
+  useEffect(() => {
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, []);
+
+  return (
+    <div className="flex items-center gap-4 h-28 pl-20" onClick={toggleDropdown} ref={dropdownRef}>
+      <div className="relative w-35 h-35 rounded-4 overflow-hidden">
+        <Image
+          fill
+          src={user.profileImgUrl ? user.profileImgUrl : '/images/default-profile.jpeg'}
+          alt="유저 프로필 이미지"
+        />
+      </div>
+      <div className="ml-5">{user.name} 님</div>
+      <button className="flex items-center justify-center w-20 h-20 text-13 font-bold ml-8 text-gray bg-[#F9FAFB] rounded-[0.25rem]">
+        <Image
+          src={isOpen ? '/images/arrow-line-s-t.svg' : '/images/arrow-line-s.svg'}
+          alt="화살표 모양의 유저 프로필 드롭다운 버튼"
+          width={16}
+          height={16}
+        />
+      </button>
+      {isOpen && (
+        <div className="absolute top-60 w-172 pt-18 pb-10 bg-white shadow-[2px_2px_14px_8px_rgba(0,0,0,0.1)] rounded z-50">
+          <Link href="/mypage" className="flex items-center h-36 px-16 text-13 text-gray-700 hover:bg-gray-100">
+            마이페이지
+          </Link>
+          <button
+            onClick={handleLogout}
+            className="flex items-center w-full h-36 px-16 text-13 text-gray-700 hover:bg-gray-100">
+            로그아웃
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/main/HomeMain.tsx
+++ b/src/components/main/HomeMain.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import MainLayout from '../layout/MainLayout';
-
 import TextFieldWhite from '../common/text/TextFieldWhite';
 import ActionButtonBlack from '../common/button/ActionButtonBlack';
 import IntroFirstCard from '../../../public/images/intro-first-card.svg';

--- a/src/types/common.d.ts
+++ b/src/types/common.d.ts
@@ -243,3 +243,16 @@ export interface OpinionRequestType {
   content: string;
   files: string[];
 }
+
+// GET_USER_INFO 응답
+export interface GetUserInfoType {
+  id: string;
+  clientId: string;
+  name: string;
+  email: string;
+  phone: string;
+  rate: string;
+  credit: number;
+  profileImgUrl?: string;
+  createdAt: string;
+}


### PR DESCRIPTION
1. 로그인시 localStorage에 useInfo는 저장하지 않고, token만 저장하는 걸로 변경했습니다. 
2. 로그인이 필요한 페이지의 경우 token 여부 확인해서 login화면으로 보내는걸 Header에서 처리하는 걸로 수정했습니다. 
3. Header의 프로필을 클릭했을때 나타나는 ProfileDropdown을 컴포넌트로 분리하고, 다른 곳을 클릭하면 닫히게 수정하였습니다. 

** 추후 수정해야할 부분
로그인이 필요한 페이지에 mypage path가 정확히 나오면 mypage도 추가해야합니다. 
현재 코드
`const loginRequiredPage = PATH.DASHBOARD || PATH.CREATE_URL || PATH.CREATE_IMAGE;`

![로그인](https://github.com/Si-gongan/gongbang-frontend-v2.1/assets/131663155/90d1aad6-ecfc-435b-a298-5bad28576c90)

