### PR TITLE
Design: /creact페이지의 에러메시지 Toast 수정 및 추가

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -12,6 +12,7 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import React, { useContext, useEffect, useState } from 'react';
 import { DashboardContext } from './layout';
 import ListSectionSkeletone from '@/components/main/dashboard/ListSectionSkeleton';
+import Toast from '@/components/common/toast/Toast';
 
 export default function Dashbaord() {
   const [resultData, setResultData] = useState<GetPostResponseType>();

--- a/src/components/common/toast/Toast.tsx
+++ b/src/components/common/toast/Toast.tsx
@@ -1,4 +1,3 @@
-import { TOAST_INFO } from '@/utils/constants';
 import Image from 'next/image';
 
 interface ToastProps {
@@ -9,18 +8,24 @@ interface ToastProps {
 }
 
 export default function Toast({ type = 'danger', text, size, onClose }: ToastProps) {
-  const typeData = TOAST_INFO.find((info) => info.type === type);
+  const TOAST_INFO = [
+    { type: 'info', imageUrl: '', style: 'bg-grey/3 text-grey7' },
+    { type: 'success', imageUrl: '/images/toast-check.svg', style: 'bg-sub/green-0 text-white' },
+    { type: 'danger', imageUrl: '/images/toast-alert.svg', style: 'bg-sub/red-0 text-white' },
+  ];
 
-  if (!typeData) return;
+  const typeData = TOAST_INFO.find((info) => info.type === type);
 
   return (
     <div
-      className={`flex items-center justify-between px-15 rounded-t-0 rounded-b-6 ${typeData?.style} ${size ? size : 'h-53 w-full'}`}>
+      className={`flex items-center justify-between px-15 rounded-t-0 rounded-b-6 z-z-DEFAULT ${typeData?.style} ${size ? size : 'h-53 w-full'}`}>
       <div className="flex items-center gap-11">
-        <Image src={typeData.imageUrl} width={24} height={24} alt="경고 아이콘" />
+        <Image src={typeData!.imageUrl} width={24} height={24} alt="경고 아이콘" />
         {text}
       </div>
-      <Image src="/images/toast-close.svg" width={24} height={24} alt="닫힘 아이콘 버튼" onClick={onClose} />
+      {onClose && (
+        <Image src="/images/toast-close.svg" width={24} height={24} alt="닫힘 아이콘 버튼" onClick={onClose} />
+      )}
     </div>
   );
 }

--- a/src/components/main/create/SectionLayout.tsx
+++ b/src/components/main/create/SectionLayout.tsx
@@ -8,7 +8,7 @@ interface SectionLayoutProps {
 
 export default function SectionLayout({ title, description, children }: SectionLayoutProps) {
   return (
-    <section className="flex flex-col gap-20 w-full">
+    <section className="relative flex flex-col gap-20 w-full">
       <div className="flex flex-col gap-10">
         {title && <h2 className="text-18 font-bold text-grey/7">{title}</h2>}
         {description && <p className="font-bole text-grey/6">{description}</p>}

--- a/src/components/main/create/TabUrllSection.tsx
+++ b/src/components/main/create/TabUrllSection.tsx
@@ -7,10 +7,10 @@ import UrlListTable from './UrlListTable';
 import { PreviewImageItemType, ScrapImagesResponseType } from '@/types/common';
 import { API_ROUTE } from '@/utils/routes';
 import { fetchWithInterceptor } from '@/utils/fetchWithInterceptor';
-import ModalLoading from '@/components/common/modal/ModalLoading';
 import CreateButtons from './CreateButtons';
 import RequestForExpert from './RequestForExpert';
 import UrlInputField from '@/components/common/input/UrlInputField';
+import Toast from '@/components/common/toast/Toast';
 
 export default function TabUrlSection() {
   const [urls, setUrls] = useState<string[]>([]);
@@ -70,7 +70,6 @@ export default function TabUrlSection() {
     <>
       {progressStage === 'one' ? (
         <div className="flex flex-col mt-40 items-center w-980 gap-100 mb-136">
-          {loading && <ModalLoading>이미지 미리보기를 불러오는 중입니다!</ModalLoading>}
           <SectionLayout>
             <form onSubmit={handleSubmitUrl}>
               <UrlInputField name="url" placeholder="웹 URL 주소를 입력해주세요" buttonText="확인" loading={loading} />
@@ -80,6 +79,13 @@ export default function TabUrlSection() {
             <UrlListTable urls={urls} setUrls={setUrls} selectedUrls={selectedUrls} setSelectedUrls={setSelectedUrls} />
           </SectionLayout>
           <SectionLayout title="이미지 미리보기" description="대체텍스트 생성할 이미지를 선택해주세요.">
+            {loading && (
+              <Toast
+                type="danger"
+                text="이미지를 불러오는 중입니다. 잠시만 기다려주세요."
+                size="absolute top-2 right-0 h-53 w-710"
+              />
+            )}
             <ImageListTable
               previewImages={previewImages}
               setPreviewImages={setPreviewImages}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -152,12 +152,6 @@ export const MYPAGE_SIDEMENU = [
   { url: PATH.MYPAGE_PAYMENT, text: '결제 정보' },
 ];
 
-export const TOAST_INFO = [
-  { type: 'info', imageUrl: '', style: 'bg-grey/3 text-grey7' },
-  { type: 'success', imageUrl: '/images/toast-check.svg', style: 'bg-sub/green-0 text-white' },
-  { type: 'danger', imageUrl: '/images/toast-alert.svg', style: 'bg-sub/red-0 text-white' },
-];
-
 export const TEMP_PLANS_INFO = [
   {
     credits: '100 credits',


### PR DESCRIPTION
1. /create/url 페이지에서 url입력 후 이미지 미리보기 리스트를 불러오는 동안 "이미지를 불러오는 중입니다. 잠시만 기다려주세요." Toast 보여줍니다.
2. /create/image 페이지에서 type이 jpg, gif, webp 아닌 경우 '파일 형식은  JPEF, PNG, GIP, WEBP만 가능합니다.' Toast 보여줍니다.


**참고
정확히 말하면 Toast는 아니지만 처음에 화면 아래서 살짝 튀어나오는 걸로 작업해서 Toast라는 컴포넌트명을 유지합니다. 

![url 에러](https://github.com/Si-gongan/gongbang-frontend-v2.1/assets/131663155/7193d195-a494-4e2f-83e9-bb85e6a74d7a)

![image](https://github.com/Si-gongan/gongbang-frontend-v2.1/assets/131663155/db1a5b04-0755-45d6-98a5-029f6b5a202b)


