### PR TITLE
Fix: /create 이미지미리보기의 맞춤형 키워드 추가할때 키워드 저장되는 방식과 모달 밖 눌렀을때 닫히게 수정

### DIFF
--- a/src/components/common/modal/ModalConfirm.tsx
+++ b/src/components/common/modal/ModalConfirm.tsx
@@ -1,21 +1,25 @@
 import Image from 'next/image';
 import { createPortal } from 'react-dom';
 import ActionButtonGray from '../button/ActionButtonGray';
+import { useRouter } from 'next/navigation';
 
 interface ModalConfirm {
   title: string;
   description?: string;
   style?: string; // width, height 등
   buttonText?: string;
+  onClick?: () => void;
   onClose?: () => void;
 }
 
-export default function ModalConfirm({ title, description, style, buttonText, onClose }: ModalConfirm) {
+export default function ModalConfirm({ title, description, style, buttonText, onClick, onClose }: ModalConfirm) {
+  const router = useRouter();
   return createPortal(
     <div
       onClick={onClose}
       className="fixed inset-0 flex justify-center items-center h-full w-full bg-overlay z-overlay">
       <div
+        onClick={(event) => event.stopPropagation()}
         className={`relative flex flex-col items-center pt-70 pb-60 gap-40 z-modal bg-white shadow-2xl rounded-4 ${
           style ? style : 'w-700'
         }`}>
@@ -24,7 +28,11 @@ export default function ModalConfirm({ title, description, style, buttonText, on
           <h2 className="text-27 font-bold text-center">{title}</h2>
           {description}
         </div>
-        <ActionButtonGray text={buttonText ? buttonText : '확인'} size="w-275 h-70 text-17" />
+        <ActionButtonGray
+          text={buttonText ? buttonText : '확인'}
+          size="w-275 h-70 text-17"
+          onClick={onClick ? onClick : onClose}
+        />
         <button className="absolute -right-52 top-0 w-48 h-48" onClick={onClose}>
           <Image fill src="/images/modal-close.svg" alt="모달창 닫기 버튼" />
         </button>

--- a/src/components/main/create/RequestForExpert.tsx
+++ b/src/components/main/create/RequestForExpert.tsx
@@ -33,6 +33,12 @@ export default function RequestForExpert({ type = 'url', selectedImages, setProg
     router.push(PATH.MYPAGE_PAYMENT);
   };
 
+  const handleToBack = () => {
+    setShowModalConfirm(false);
+
+    window.location.reload();
+  };
+
   const handleClickRequest = async () => {
     const selectedImagesWorks = await Promise.all(
       selectedImages.map(async (selectedImage) => {
@@ -101,6 +107,7 @@ export default function RequestForExpert({ type = 'url', selectedImages, setProg
           description="서비스가 정상적으로 접수되었습니다"
           buttonText="확인"
           onClose={() => setShowModalConfirm(false)}
+          onClick={handleToBack}
         />
       )}
       {showModalError && (


### PR DESCRIPTION
1. /create의 이미지 미리보기 테이블의 맞춤형 키워드 [추가하기] 눌렀을때 나타나는 ModalAddKeywords의 모달 외부 클릭했을때 닫히게 수정하였습니다. 
2. ModalAddKeywords에 키워드 저장을 useEffect로 키워드가 변경되는 것을 감지해서 키워드가 저장되도록 하였습니다. 
3. /create의 해설진 작성 세부 요청서를 쓰고 요청했을때 '서비스접수완료' 모달의 확인 누르면 reload 되어 리셋되게 변경하였습니다. 