### PR TITLE
Fix: /support/notice와 /faq 페이지가 바뀔때마다 SupportImageSection의 tabButton …

### DIFF
--- a/src/components/main/support/SupportImageSection.tsx
+++ b/src/components/main/support/SupportImageSection.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Image from 'next/image';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import TabButton from './TabButton';
 import { usePathname } from 'next/navigation';
 
@@ -10,9 +10,12 @@ export default function SupportImageSection() {
   const parts = pathname.split('/');
   const currentPage = parts[2];
 
-  const initialPage = currentPage === 'notice' ? { id: 'notice', text: '공지사항' } : { id: 'faq', text: 'FAQ' };
+  const [page, setPage] = useState({ id: 'notice', text: '공지사항' });
 
-  const [page, setPage] = useState(initialPage);
+  useEffect(() => {
+    const initialPage = currentPage === 'notice' ? { id: 'notice', text: '공지사항' } : { id: 'faq', text: 'FAQ' };
+    setPage(initialPage);
+  }, [currentPage]);
 
   return (
     <section className="w-full flex justify-center items-center h-357 bg-[url('/images/support-image.png')] bg-cover bg-center">


### PR DESCRIPTION
1. /support의 tabButton이 페이지에 맞춰 바뀌도록 수정하였습니다. 
   문제: /support/notice에서 /support/faq 갔다가 뒤로가기를 하면 url은 변경되는데 tab이 계속 faq를 가리키고 있는 문제를 발견
   해결: useEffect로 currentPage가 바뀔때마다 tabButton으로 props으로 내려주는 page 상태를 업데이트 시켰습니다.