### PR TITLE
Fix: /dashboard의 sort,searchValue,pagination.click에 따라 결과값 나오는 로직 변경

### DIFF
--- a/src/components/main/dashboard/DashboardContent.tsx
+++ b/src/components/main/dashboard/DashboardContent.tsx
@@ -6,7 +6,6 @@ import SortDropdown from '@/components/main/dashboard/SortDropdown';
 import { DashbaordSortType, GetPostResponseType } from '@/types/common';
 import { DASHBOARD_LIMIT } from '@/utils/constants';
 import { fetchWithInterceptor } from '@/utils/fetchWithInterceptor';
-import { initUrlParams } from '@/utils/initUrlParams';
 import { API_ROUTE, PATH } from '@/utils/routes';
 import { useRouter, useSearchParams } from 'next/navigation';
 import React, { useContext, useEffect, useState } from 'react';
@@ -23,7 +22,6 @@ export default function DashboardContent() {
   const searchParams = useSearchParams();
   const params = new URLSearchParams(searchParams);
 
-  // const items = (resultData && (resultData.hasOwnProperty('posts') ? resultData.posts : resultData?.inspects)) || [];
   const items = (resultData && ('posts' in resultData ? resultData.posts : resultData?.inspects)) || [];
 
   const handleSubmitSearch = (event: React.MouseEvent<HTMLFormElement>) => {
@@ -81,11 +79,6 @@ export default function DashboardContent() {
       setLoading(false);
     }
   };
-
-  useEffect(() => {
-    initUrlParams({ params, setSort, setSearchValue, setPagination });
-    getResultItem();
-  }, []);
 
   useEffect(() => {
     getResultItem();

--- a/src/components/main/dashboard/PostIdTitle.tsx
+++ b/src/components/main/dashboard/PostIdTitle.tsx
@@ -1,13 +1,11 @@
 import ActionButton from '@/components/common/button/ActionButton';
 import ActionButtonGray from '@/components/common/button/ActionButtonGray';
 import { getResultDetailTitle } from '@/utils/getResultDetailTitle';
-import { useRouter, useSearchParams } from 'next/navigation';
+import { useRouter } from 'next/navigation';
 import SortDropdown from './SortDropdown';
 import { DashbaordSortType, WorkType } from '@/types/common';
 import DownloadDropdown from './DownloadDropdown';
-import { useContext } from 'react';
 import { PATH } from '@/utils/routes';
-import { DashboardContext } from './DashboradContextMain';
 
 interface PostIdTitleProps {
   target: string;
@@ -30,22 +28,14 @@ export default function PostIdTitle({
   setTableSort,
   selectedWorks,
 }: PostIdTitleProps) {
-  const { replace } = useRouter();
-  const searchParams = useSearchParams();
-  const params = new URLSearchParams(searchParams);
-
-  let { sort, pagination, searchValue } = useContext(DashboardContext);
+  const router = useRouter();
 
   const aiCompletedPage = target === 'ai';
   const inspectCompletedPage = target === 'inspect' && isComplete;
   const titleDescription = getResultDetailTitle(target, isComplete, requestExpertPage);
 
   const goBack = () => {
-    params.set('sort', sort.id);
-    params.set('search', searchValue);
-    params.set('page', String(pagination.click));
-
-    replace(`${PATH.DASHBOARD}?${params.toString()}`);
+    router.replace(PATH.DASHBOARD);
   };
 
   const handleClickSort = (selectedSort: DashbaordSortType) => {


### PR DESCRIPTION
1. /dashboard의 sort,searchValue,pagination.click에 따라 데이터 결과값 나오는 코드를 정리했습니다. 
   변경사항: initUrlParams를 사용해서 url에서 sort,searchValue,pagination.click값을 가져와서 상태 업데이트하고 api 요청을 했는데 이부분을 아예 걷어냈습니다. 