### PR TITLE
Chore: 페이지 이동시 스크롤 최상단에 위치하도록 수정

### DIFF
--- a/src/app/plans/page.tsx
+++ b/src/app/plans/page.tsx
@@ -28,6 +28,8 @@ export default function Plans() {
 
   useEffect(() => {
     getUserInfo();
+
+    window.scrollTo(0, 0);
   }, []);
 
   const handleClick = async (i: number) => {

--- a/src/app/support/faq/page.tsx
+++ b/src/app/support/faq/page.tsx
@@ -46,6 +46,10 @@ export default function FaqPage() {
     getFaqList();
   }, [tab, pagination.click]);
 
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
+
   return (
     <section className="flex flex-col items-center w-980 pt-40 gap-100 mb-125">
       <div className="flex flex-col items-center gap-16">

--- a/src/app/support/notice/page.tsx
+++ b/src/app/support/notice/page.tsx
@@ -46,6 +46,8 @@ export default function NoticePage() {
 
   useEffect(() => {
     getNoticeList();
+
+    window.scrollTo(0, 0);
   }, []);
 
   return (

--- a/src/components/main/create/TabImageSection.tsx
+++ b/src/components/main/create/TabImageSection.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import SectionLayout from './SectionLayout';
 import FileInputField from '@/components/common/input/FileInputField';
 import { PreviewImageItemType } from '@/types/common';
@@ -15,6 +15,10 @@ export default function TabImageSection() {
   const [previewImages, setPreviewImages] = useState<PreviewImageItemType[]>([]);
   const [progressStage, setProgressStage] = useState('one'); // one: url 입력, two: 해설진 작성
   const [toastMessage, setToastMessage] = useState('');
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
 
   return (
     <>

--- a/src/components/main/create/TabUrllSection.tsx
+++ b/src/components/main/create/TabUrllSection.tsx
@@ -78,6 +78,10 @@ export default function TabUrlSection() {
     setPreviewImages(updatedPreviewImages);
   }, [urls]);
 
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
+
   return (
     <>
       {progressStage === 'one' ? (


### PR DESCRIPTION
1. 페이지를 이동할때 이전 스크롤 위치가 유지되었던 것을 항상 스크롤이 위로 올라가 있도록 수정하였습니다. 