### PR TITLE
Design: 회원가입시 이용약관 볼 수 있는 모달창 구현

### DIFF
--- a/src/components/common/modal/ModalTerm.tsx
+++ b/src/components/common/modal/ModalTerm.tsx
@@ -15,7 +15,7 @@ export default function ModalTerm({ onClose }: ModalTermProps) {
       <div
         onClick={(e) => e.stopPropagation()}
         className="relative flex flex-col items-center p-40 gap-40 z-modal bg-white shadow-2xl rounded-4 w-700 h-600">
-        <h1 className="text-22 font-bold">이용약관</h1>
+        <h1 className="text-22 font-bold">에이택 웹사이트 이용약관</h1>
         <div className="flex flex-col gap-40 h-400 overflow-y-scroll scroll-block">
           <div className="flex flex-col gap-12 text-14">
             {POLICY_SERVICE.map((policy) => (


### PR DESCRIPTION
1. 회원가입시 이용약관 [보기] 클릭시 나타나는 ModalTerm 스타일 수정



<img width="976" alt="스크린샷 2024-06-20 오후 7 59 15" src="https://github.com/Si-gongan/atag-frontend/assets/131663155/edf36cb8-03aa-4f57-abf8-4e95cad3ccdb">
